### PR TITLE
Fix `jsonify` to convert the correct value to JSON.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
   - git clone https://github.com/tfutils/tfenv.git ~/.tfenv
   - export PATH="$HOME/.tfenv/bin:$PATH"
   - tfenv install $TFVER
+  - tfenv use $TFVER
   - terraform --version
   - gem update --system
   - gem install bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,7 @@ DEPENDENCIES
   coveralls
   pry
   pry-byebug
-  rake
+  rake (>= 12.3.3)
   rspec
   simplecov
   simplygenius-atmos!

--- a/atmos.gemspec
+++ b/atmos.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "coveralls"

--- a/lib/simplygenius/atmos/commands/tfutil.rb
+++ b/lib/simplygenius/atmos/commands/tfutil.rb
@@ -61,7 +61,7 @@ module SimplyGenius
                 result[k] = ev
               end
             else
-              result["data"] = JSON.generate(result)
+              result["data"] = JSON.generate(obj)
             end
 
             return result

--- a/spec/commands/tfutil_spec.rb
+++ b/spec/commands/tfutil_spec.rb
@@ -100,6 +100,8 @@ module SimplyGenius
         describe "terraform external constraints" do
 
           it "outputs terraform friendly json" do
+            skip("test is for newer terraform only") if `terraform version` =~ /0.11/
+
             within_construct do |c|
               c.file('config/atmos.yml', "")
               c.file('test.tf', <<~EOF

--- a/spec/integration/initial_setup_spec.rb
+++ b/spec/integration/initial_setup_spec.rb
@@ -3,9 +3,6 @@ require 'simplygenius/atmos/settings_hash'
 
 describe "Initial Setup" do
 
-  let(:exe) { File.expand_path('../../../exe/atmos', __FILE__) }
-  let(:gemfile) { File.expand_path('../../../Gemfile', __FILE__) }
-
   let(:recipes_sourcepath) {
     if ENV['CI'].present?
       ["--no-sourcepaths", "--sourcepath", 'https://github.com/simplygenius/atmos-recipes.git']
@@ -13,19 +10,6 @@ describe "Initial Setup" do
       ["--no-sourcepaths", "--sourcepath", File.expand_path('../../../../atmos-recipes', __FILE__)]
     end
   }
-
-  def atmos(*args, output_on_fail: true, allow_fail: false, stdin_data: nil)
-    args = args.compact
-    require 'bundler'
-    ::Bundler.with_original_env do
-      output, status = Open3.capture2e(ENV.to_h.merge("BUNDLE_GEMFILE" => gemfile), "bundle", "exec", exe, *args, stdin_data: stdin_data)
-      puts output if output_on_fail && status.exitstatus != 0
-      if ! allow_fail
-        expect(status.exitstatus).to eq(0), "atmos #{args.join(' ')} failed: #{output}"
-      end
-      return output
-    end
-  end
 
   describe "executable" do
 


### PR DESCRIPTION
I think the change I'm making here is correct. If the JSON data provided to `jsonify -j` isn't a `Hash`, the `flatten` utility would basically discard all of it, which I don't think is what was intended.